### PR TITLE
Add ZMQ subscribers.

### DIFF
--- a/src/zmq_sub.cpp
+++ b/src/zmq_sub.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 <Admobilize>
+ * MATRIX Labs  [http://creator.matrix.one]
+ * This file is part of MATRIX Creator MALOS
+ *
+ * MATRIX Creator MALOS is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "./zmq_sub.h"
+
+namespace matrix_malos {
+
+bool ZmqSubscriber::Init(const std::string &host, int port, int high_water_mark,
+                         const std::string &topic, int n_threads) {
+  // Get the context first.
+  context_.reset(new zmq::context_t(n_threads));
+
+  // Now get the socket.
+  socket_.reset(new zmq::socket_t(*context_.get(), ZMQ_SUB));
+
+  // Connect to the remote host.
+  socket_->connect("tcp://" + host + ":" + std::to_string(port));
+
+  // Set high water mark.
+  socket_->setsockopt(ZMQ_SNDHWM, (void *)&high_water_mark,
+                      sizeof(high_water_mark));
+
+  // Topic we're interested in.
+  socket_->setsockopt(ZMQ_SUBSCRIBE, topic.c_str(), topic.size());
+
+  // Assume things went well.
+  return true;
+}
+
+bool ZmqSubscriber::Poll(int timeout_ms) {
+  // Polling a single socket.
+  zmq::pollitem_t poll_items[] = {
+      {static_cast<void *>(*socket_.get()), 0, ZMQ_POLLIN, 0},
+  };
+  // Wait for message.
+  zmq::poll(&poll_items[0], 1, timeout_ms);
+  // Returns true if a message arrives.
+  return poll_items[0].revents & ZMQ_POLLIN;
+}
+
+std::string ZmqSubscriber::Read() {
+  zmq::message_t message;
+  // Read the message from the socket.
+  socket_->recv(&message);
+  // Convert to string and return.
+  std::string ret;
+  ret.assign(static_cast<char *>(message.data()), message.size());
+  return ret;
+}
+
+} // namespace  matrix_malos

--- a/src/zmq_sub.h
+++ b/src/zmq_sub.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 <Admobilize>
+ * MATRIX Labs  [http://creator.matrix.one]
+ * This file is part of MATRIX Creator MALOS
+ *
+ * MATRIX Creator MALOS is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SRC_ZMQ_SUB_H_
+#define SRC_ZMQ_SUB_H_
+
+#include <memory>
+#include <string>
+
+#include "third_party/zmq.hpp"
+
+namespace matrix_malos {
+
+// This class is used to subscribe to ZMQ messages.
+// A small wrapper to make code cleaner in upper layers.
+class ZmqSubscriber {
+public:
+  ZmqSubscriber() {}
+
+  enum { WAIT_FOREVER = -1 };
+
+  // Initialize the subscriber and make it connect to a host/port.
+  // The default topic "" means subscribe to all messages.
+  bool Init(const std::string &host, int port, int high_water_mark,
+            const std::string &topic = "", int n_threads = 1);
+
+  // Wait for messages. Timeout in milliseconds.
+  // Returns true if a message arrives.
+  bool Poll(int timeout_ms);
+
+  // Read messages when polling is successful.
+  std::string Read();
+
+private:
+  std::unique_ptr<zmq::context_t> context_;
+  std::unique_ptr<zmq::socket_t> socket_;
+};
+
+} // namespace matrix_malos
+
+#endif // SRC_ZMQ_PULL_H_


### PR DESCRIPTION
This is useful as well and it's missing, even when it's not used by MALOS.
That's because all subscriptions have been done from JS and when using C++ we haven't used a wrapper.

We should factor the subscriber and the puller with a base class because the methods Read and Poll are identical. But let's not do it now because we'll need to modify the headers and test the Debian packages.