### PR TITLE
Change communication channels

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,11 +31,9 @@ set(matrix_malos_zmq_src
 )
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-if (MSVC)
-  add_library(matrix_malos_zmq ${matrix_malos_zmq_src})
-else ()
-  add_library(matrix_malos_zmq SHARED ${matrix_malos_zmq_src})
-endif ()
+
+add_library(matrix_malos_zmq ${matrix_malos_zmq_src})
+
 set_property(TARGET matrix_malos_zmq PROPERTY CXX_STANDARD 11)
 target_link_libraries(matrix_malos_zmq ${ZMQ_LIB} ${CMAKE_THREAD_LIBS_INIT})
 
@@ -43,23 +41,17 @@ set(matrix_malos_src
   malos_base.cpp malos_base.h
   driver_manager.cpp driver_manager.h
 )
-if (MSVC)
-  add_library(matrix_malos ${matrix_malos_src})
-  set_property(TARGET matrix_malos PROPERTY CXX_STANDARD 11)
-  target_link_libraries(matrix_malos matrix_malos_zmq.dll)
+add_library(matrix_malos ${matrix_malos_src})
+set_property(TARGET matrix_malos PROPERTY CXX_STANDARD 11)
+target_link_libraries(matrix_malos matrix_malos_zmq)
+target_link_libraries(matrix_malos ${MATRIX_PROTOS_LIB})
+target_link_libraries(matrix_malos ${CMAKE_THREAD_LIBS_INIT})
 
+if (MSVC)
   include_directories(${ZMQ_INCLUDE_DIR})
   include_directories(${MATRIX_PROTOS_INCLUDE_DIR})
   include_directories(${PROTOBUF_INCLUDE_DIR})
-else ()
-  add_library(matrix_malos SHARED ${matrix_malos_src})
-  set_property(TARGET matrix_malos PROPERTY CXX_STANDARD 11)
-  target_link_libraries(matrix_malos matrix_malos_zmq)
-endif ()
-
-  target_link_libraries(matrix_malos ${MATRIX_PROTOS_LIB})
-  target_link_libraries(matrix_malos ${CMAKE_THREAD_LIBS_INIT})
-
+endif()
 
 # Binary to be installed.
 install(TARGETS matrix_malos_zmq DESTINATION lib)

--- a/src/malos_base.cpp
+++ b/src/malos_base.cpp
@@ -150,9 +150,16 @@ void MalosBase::KeepAliveThread(const std::string &bind_scope, int port) {
   zmq::context_t context(kOneThread);
   zmq::socket_t socket(context, ZMQ_REP);
   socket.bind("tcp://" + bind_scope + ":" + std::to_string(port));
+
+  int last_set_timeout = timeout_after_last_ping_;
   socket.setsockopt(ZMQ_RCVTIMEO, timeout_after_last_ping_);
 
   while (true) {
+    if (timeout_after_last_ping_ != last_set_timeout) {
+      socket.setsockopt(ZMQ_RCVTIMEO, timeout_after_last_ping_);
+      last_set_timeout = timeout_after_last_ping_;
+    }
+
     zmq::message_t request;
     zmq::message_t reply(0);
 

--- a/src/malos_base.cpp
+++ b/src/malos_base.cpp
@@ -80,7 +80,7 @@ void MalosBase::ConfigThread() {
       if (!config.ParseFromString(zmq_pull_config_->Read())) {
         std::cerr << "Invalid configuration for " << driver_name_ << " driver."
                   << std::endl;
-        SendStatus(pb::driver::Status::ERROR, "",
+        SendStatus(pb::driver::Status::STATUS_ERROR, "",
                    "Invalid configuration for " + driver_name_ +
                        " driver. Could not parse protobuf.");
 
@@ -93,7 +93,7 @@ void MalosBase::ConfigThread() {
       // the camera and the detectors need to be configured.
       if (!ProcessConfig(config)) {
         std::cerr << "Specific config for " << driver_name_ << " failed.";
-        SendStatus(pb::driver::Status::ERROR, "",
+        SendStatus(pb::driver::Status::STATUS_ERROR, "",
                    "Invalid specific configuration for " + driver_name_ +
                        " driver. Could not parse protobuf.");
 
@@ -137,7 +137,7 @@ void MalosBase::UpdateThread() {
       continue;
     }
     if (!SendUpdate()) {
-      SendStatus(pb::driver::Status::ERROR, "",
+      SendStatus(pb::driver::Status::STATUS_ERROR, "",
                  "Could not send update for " + driver_name_ + " driver.");
     }
     config_mutex_.unlock();

--- a/src/malos_base.cpp
+++ b/src/malos_base.cpp
@@ -150,6 +150,7 @@ void MalosBase::KeepAliveThread(const std::string &bind_scope, int port) {
   zmq::context_t context(kOneThread);
   zmq::socket_t socket(context, ZMQ_REP);
   socket.bind("tcp://" + bind_scope + ":" + std::to_string(port));
+  socket.setsockopt(ZMQ_RCVTIMEO, timeout_after_last_ping_);
 
   while (true) {
     zmq::message_t request;

--- a/src/malos_base.h
+++ b/src/malos_base.h
@@ -45,7 +45,7 @@ class MalosBase {
   // Thread that send updates to subscribers.
   void UpdateThread();
   // Thead that receives the keepalives.
-  void KeepAliveThread();
+  void KeepAliveThread(const std::string &bind_scope, int port);
 
   // This function should be overridden by drivers. Where is where they send
   // updates to subscribed processes.

--- a/src/malos_base.h
+++ b/src/malos_base.h
@@ -77,6 +77,8 @@ class MalosBase {
   // Fill out information about the driver.
   void FillOutDriverInfo(pb::driver::DriverInfo *driver_info) const;
 
+  bool IsActive() const { return is_active_; }
+
  private:
   // Base por of the driver.
   int base_port_;
@@ -109,9 +111,13 @@ class MalosBase {
 
  protected:
   // ZMQ channel where errors are sent.
-  std::unique_ptr<ZmqPusher> zmq_push_error_;
+  std::unique_ptr<ZmqPusher> zmq_push_status_;
   // ZMQ channel where actual data updates are sent.
   std::unique_ptr<ZmqPusher> zqm_push_update_;
+
+  void SendStatus(const pb::driver::Status::MessageType &type,
+                  const std::string &uuid = "",
+                  const std::string &message = "");
 };
 
 }  // namespace matrix_malos


### PR DESCRIPTION
Change keep-alive communication model to pong requests and change `error channel` to `status channel` for more general notifications.